### PR TITLE
Fix Cargo.toml

### DIFF
--- a/fiability2016/Cargo.toml
+++ b/fiability2016/Cargo.toml
@@ -39,11 +39,3 @@ gmp = ["rust-gmp"]
 [dependencies.rust-gmp]
 version = "0.2.10"
 optional = true
-
-[[bin]]
-name = "paint"
-path = "src/demos/paint.rs"
-
-[[bin]]
-name = "mandelbrot"
-path = "src/demos/mandelbrot.rs"


### PR DESCRIPTION
Fix `Cargo.toml` by removing references to demo programs from the qcon directory that were not copied into fiability2016.
